### PR TITLE
#9: クリックした方向に弾を発射するように変更

### DIFF
--- a/src/events/handleClick.js
+++ b/src/events/handleClick.js
@@ -1,8 +1,14 @@
 import { gameState } from "../../index.js";
 
 export const handleClick = (event) => {
+  const player = gameState.getPlayerObj();
+  const playerX = player.x;
+  const playerY = player.y;
+  const clickX = event.clientX;
+  const clickY = event.clientY;
+
   console.log("click: " + event.button);
   if (event.button === 0) {
-    gameState.shoot();
+    gameState.shoot(Math.atan2(clickY - playerY, clickX - playerX));
   }
 }

--- a/src/objects/PlayerBullet.js
+++ b/src/objects/PlayerBullet.js
@@ -2,12 +2,14 @@ import { PLAYER_BULLET_SPEED, PLAYER_BULLET_WIDTH, PLAYER_BULLET_HEIGHT, PLAYER_
 import { GameObject } from "./GameObject.js";
 
 export class PlayerBullet extends GameObject {
-  constructor(x, y) {
+  constructor(x, y, direction) {
     super(x, y, PLAYER_BULLET_WIDTH, PLAYER_BULLET_HEIGHT, PLAYER_BULLET_COLOR);
+    this.direction = direction;
   }
 
   updatePosition() {
-    this.y += PLAYER_BULLET_SPEED;
+    this.x += PLAYER_BULLET_SPEED * Math.cos(this.direction);
+    this.y += PLAYER_BULLET_SPEED * Math.sin(this.direction);
   }
 }
 

--- a/src/states/GameState.js
+++ b/src/states/GameState.js
@@ -64,10 +64,11 @@ export class GameState {
   // 弾関連
   /**
    * 射撃処理
+   * @param {number} direction 射撃方向（ラジアン角度で指定）
    */
-  shoot() {
+  shoot(direction) {
     const player = this.getPlayerObj();
-    const bullet = new PlayerBullet(player.x, player.y);
+    const bullet = new PlayerBullet(player.x, player.y, direction);
     this.objects.push(bullet);
   }
 


### PR DESCRIPTION
# Linked Issues
#9 

# Feature
クリックした方向へ弾を発射するようにした。
![7ed81515441020d821893e004339ca8b](https://github.com/ulxsth/shooting-test/assets/114195789/70b83bca-2d31-4f95-a91d-b5948cb846d6)

方法としては、
- 発射時にPlayerShipからクリックした地点への角度を計算する
```js
export const handleClick = (event) => {
  const player = gameState.getPlayerObj();
  const playerX = player.x;
  const playerY = player.y;
  const clickX = event.clientX;
  const clickY = event.clientY;

  console.log("click: " + event.button);
  if (event.button === 0) {
    gameState.shoot(Math.atan2(clickY - playerY, clickX - playerX));
  }
}
```

- `PlayerBullet` に `direction` を追加、角度を鑑みた位置更新を行うように
```js
export class PlayerBullet extends GameObject {
  constructor(x, y, direction) {
    super(x, y, PLAYER_BULLET_WIDTH, PLAYER_BULLET_HEIGHT, PLAYER_BULLET_COLOR);
    this.direction = direction;
  }

  updatePosition() {
    this.x += PLAYER_BULLET_SPEED * Math.cos(this.direction);
    this.y += PLAYER_BULLET_SPEED * Math.sin(this.direction);
  }
}
```