### PR TITLE
#14: プレイヤーの移動を画面内に制限

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,6 +37,9 @@ import { EnemyObject } from "./src/objects/EnemyObject.js";
 const canvas = document.getElementById("mainCanvas");
 const ctx = canvas.getContext("2d");
 
+export const canvasWidth = canvas.width;
+export const canvasHeight = canvas.height;
+
 export const gameState = new GameState();
 
 /**

--- a/index.js
+++ b/index.js
@@ -37,9 +37,6 @@ import { EnemyObject } from "./src/objects/EnemyObject.js";
 const canvas = document.getElementById("mainCanvas");
 const ctx = canvas.getContext("2d");
 
-export const canvasWidth = canvas.width;
-export const canvasHeight = canvas.height;
-
 export const gameState = new GameState();
 
 /**
@@ -95,6 +92,10 @@ function init() {
 
 function getCenterOfCanvas() {
   return { x: canvas.width / 2, y: canvas.height / 2 };
+}
+
+export function getCanvasSize() {
+  return { width: canvas.width, height: canvas.height };
 }
 
 init();

--- a/src/objects/PlayerShip.js
+++ b/src/objects/PlayerShip.js
@@ -1,5 +1,11 @@
 import { GameObject } from "./GameObject.js";
-import { PLAYER_SHIP_WIDTH, PLAYER_SHIP_HEIGHT, PLAYER_SHIP_COLOR, PLAYER_SPEED } from "../constants.js";
+import {
+  PLAYER_SHIP_WIDTH,
+  PLAYER_SHIP_HEIGHT,
+  PLAYER_SHIP_COLOR,
+  PLAYER_SPEED,
+} from "../constants.js";
+import { canvasWidth, canvasHeight } from "../index.js";
 
 export class PlayerShip extends GameObject {
   constructor(x, y) {
@@ -7,10 +13,11 @@ export class PlayerShip extends GameObject {
   }
 
   updatePosition(flags) {
-    if (flags.up) this.y -= PLAYER_SPEED;
-    if (flags.down) this.y += PLAYER_SPEED;
-    if (flags.left) this.x -= PLAYER_SPEED;
-    if (flags.right) this.x += PLAYER_SPEED;
+    if (flags.up && this.y > 0) this.y -= PLAYER_SPEED;
+    if (flags.left && this.x > 0) this.x -= PLAYER_SPEED;
+    if (flags.down && this.y < canvasHeight - PLAYER_SHIP_HEIGHT)
+      this.y += PLAYER_SPEED;
+    if (flags.right && this.x < canvasWidth - PLAYER_SHIP_WIDTH)
+      this.x += PLAYER_SPEED;
   }
 }
-

--- a/src/objects/PlayerShip.js
+++ b/src/objects/PlayerShip.js
@@ -5,7 +5,7 @@ import {
   PLAYER_SHIP_COLOR,
   PLAYER_SPEED,
 } from "../constants.js";
-import { canvasWidth, canvasHeight } from "../index.js";
+import { getCanvasSize } from "../../index.js";
 
 export class PlayerShip extends GameObject {
   constructor(x, y) {
@@ -13,11 +13,19 @@ export class PlayerShip extends GameObject {
   }
 
   updatePosition(flags) {
-    if (flags.up && this.y > 0) this.y -= PLAYER_SPEED;
-    if (flags.left && this.x > 0) this.x -= PLAYER_SPEED;
-    if (flags.down && this.y < canvasHeight - PLAYER_SHIP_HEIGHT)
+    const { width: canvasWidth, height: canvasHeight } = getCanvasSize();
+
+    if (flags.up && this.y - PLAYER_SPEED >= 0) {
+      this.y -= PLAYER_SPEED;
+    }
+    if (flags.left && this.x - PLAYER_SPEED >= 0) {
+      this.x -= PLAYER_SPEED;
+    }
+    if (flags.down && this.y + PLAYER_SPEED + PLAYER_SHIP_HEIGHT <= canvasHeight) {
       this.y += PLAYER_SPEED;
-    if (flags.right && this.x < canvasWidth - PLAYER_SHIP_WIDTH)
+    }
+    if (flags.right && this.x + PLAYER_SPEED + PLAYER_SHIP_WIDTH <= canvasWidth) {
       this.x += PLAYER_SPEED;
+    }
   }
 }

--- a/src/states/GameState.js
+++ b/src/states/GameState.js
@@ -89,6 +89,7 @@ export class GameState {
       bullet.updatePosition();
 
       // 画面外に出た弾をobjectsから削除
+      // TODO: 全方向に確認する
       // TODO: 計算量が O(N) （Nはすべてのオブジェクト数）なので、パフォーマンスを改善する
       if (bullet.y < 0) {
         this.objects.splice(this.objects.indexOf(bullet), 1);
@@ -123,7 +124,7 @@ export class GameState {
     const enemies = this.getAllEnemyObjects();
 
     // TODO: O(N^2) なので、パフォーマンスを改善する
-    bullets.forEach((bullet, index) => {
+    bullets.forEach((bullet) => {
       enemies.forEach((enemy) => {
         if (bullet.isCollided(enemy)) {
           this.objects.splice(this.objects.indexOf(bullet), 1);

--- a/src/states/GameState.js
+++ b/src/states/GameState.js
@@ -48,7 +48,7 @@ export class GameState {
   // プレイヤー関連
   /**
    * プレイヤーを取得する
-   * @returns {Object}
+   * @returns {PlayerShip}
    */
   getPlayerObj = () => this.objects.find((obj) => obj instanceof PlayerShip);
 
@@ -74,7 +74,7 @@ export class GameState {
 
   /**
    * プレイヤーの弾を取得する
-   * @returns {Object[]}
+   * @returns {PlayerBullet[]}
    */
   getAllPlayerBullets = () =>
     this.objects.filter((obj) => obj instanceof PlayerBullet);
@@ -99,7 +99,7 @@ export class GameState {
   // 敵オブジェクト関連
   /**
    * 敵オブジェクトを取得する
-   * @returns {Object[]}
+   * @returns {EnemyObject[]}
    */
   getAllEnemyObjects = () => this.objects.filter((obj) => obj instanceof EnemyObject);
 


### PR DESCRIPTION
# Linked Issue
#14 

# Details
プレイヤーの位置更新ロジックに、canvasWidth / Height 外に出ないかバリデーションを追加した。

```js
// PlayerShip.js

updatePosition(flags) {
    const { width: canvasWidth, height: canvasHeight } = getCanvasSize();

    if (flags.up && this.y - PLAYER_SPEED >= 0) {
      this.y -= PLAYER_SPEED;
    }
    if (flags.left && this.x - PLAYER_SPEED >= 0) {
      this.x -= PLAYER_SPEED;
    }
    if (flags.down && this.y + PLAYER_SPEED + PLAYER_SHIP_HEIGHT <= canvasHeight) {
      this.y += PLAYER_SPEED;
    }
    if (flags.right && this.x + PLAYER_SPEED + PLAYER_SHIP_WIDTH <= canvasWidth) {
      this.x += PLAYER_SPEED;
    }
  }
  ```