### PR TITLE
#22: GameStateから各処理を適切な位置に分離した

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,11 +35,13 @@ import { handleMouseMove } from "./src/events/handleMouseMove.js";
 import { GameState } from "./src/states/GameState.js";
 import { PlayerShip } from "./src/objects/PlayerShip.js";
 import { EnemyObject } from "./src/objects/EnemyObject.js";
+import { InteractionState } from "./src/states/InteractionState.js";
 
 const canvas = document.getElementById("mainCanvas");
 const ctx = canvas.getContext("2d");
 
 export const gameState = new GameState();
+export const interactionState = new InteractionState();
 export let mouseX = 0;
 export let mouseY = 0;
 

--- a/index.js
+++ b/index.js
@@ -33,6 +33,7 @@ import { handleMouseClick } from "./src/events/handleMouseDown.js";
 import { handleMouseUp } from "./src/events/handleMouseUp.js";
 import { handleMouseMove } from "./src/events/handleMouseMove.js";
 import { GameState } from "./src/states/GameState.js";
+import { PlayerShip } from "./src/objects/PlayerShip.js";
 import { EnemyObject } from "./src/objects/EnemyObject.js";
 
 const canvas = document.getElementById("mainCanvas");
@@ -73,7 +74,7 @@ function init() {
   canvas.height = document.documentElement.clientHeight;
 
   // canvas の中心にプレイヤーを配置
-  const player = gameState.getPlayerObj();
+  const player = gameState.getFirst(PlayerShip);
   const center = getCenterOfCanvas();
   player.x = center.x;
   player.y = center.y;

--- a/src/events/handleClick.js
+++ b/src/events/handleClick.js
@@ -1,7 +1,8 @@
 import { gameState } from "../../index.js";
+import { PlayerShip } from "../objects/PlayerShip.js";
 
 export const handleClick = (event) => {
-  const player = gameState.getPlayerObj();
+  const player = gameState.getFirst(PlayerShip);
   const playerX = player.x;
   const playerY = player.y;
   const clickX = event.clientX;

--- a/src/events/handleClick.js
+++ b/src/events/handleClick.js
@@ -9,6 +9,6 @@ export const handleClick = (event) => {
 
   console.log("click: " + event.button);
   if (event.button === 0) {
-    gameState.shoot(Math.atan2(clickY - playerY, clickX - playerX));
+    player.shoot(Math.atan2(clickY - playerY, clickX - playerX));
   }
 }

--- a/src/events/handleKeyDown.js
+++ b/src/events/handleKeyDown.js
@@ -1,4 +1,4 @@
-import { gameState } from "../../index.js";
+import { interactionState } from "../../index.js";
 
 export const handleKeyDown = (event) => {
   console.log("keydown: " + event.key);
@@ -7,19 +7,19 @@ export const handleKeyDown = (event) => {
   switch (event.key) {
     case "ArrowUp":
     case "w":
-      gameState.setFlag("up", true);
+      interactionState.setFlag("up", true);
       break;
     case "ArrowDown":
     case "s":
-      gameState.setFlag("down", true);
+      interactionState.setFlag("down", true);
       break;
     case "ArrowLeft":
     case "a":
-      gameState.setFlag("left", true);
+      interactionState.setFlag("left", true);
       break;
     case "ArrowRight":
     case "d":
-      gameState.setFlag("right", true);
+      interactionState.setFlag("right", true);
       break;
   }
 }

--- a/src/events/handleKeyUp.js
+++ b/src/events/handleKeyUp.js
@@ -1,23 +1,23 @@
-import { gameState } from "../../index.js";
+import { interactionState } from "../../index.js";
 
 export const handleKeyUp = (event) => {
   console.log("keyup: " + event.key);
   switch (event.key) {
     case "ArrowUp":
     case "w":
-      gameState.setFlag("up", false);
+      interactionState.setFlag("up", false);
       break;
     case "ArrowDown":
     case "s":
-      gameState.setFlag("down", false);
+      interactionState.setFlag("down", false);
       break;
     case "ArrowLeft":
     case "a":
-      gameState.setFlag("left", false);
+      interactionState.setFlag("left", false);
       break;
     case "ArrowRight":
     case "d":
-      gameState.setFlag("right", false);
+      interactionState.setFlag("right", false);
       break;
   }
 }

--- a/src/events/handleMouseDown.js
+++ b/src/events/handleMouseDown.js
@@ -1,10 +1,10 @@
-import { gameState } from "../../index.js";
+import { interactionState } from "../../index.js";
 
 export const handleMouseClick = (event) => {
   console.log("mousedown: " + event.button);
   if (event.button === 0) {
-    gameState.setFlag("leftClick", true);
+    interactionState.setFlag("leftClick", true);
   } else if (event.button === 2) {
-    gameState.setFlag("rightClick", true);
+    interactionState.setFlag("rightClick", true);
   }
 }

--- a/src/events/handleMouseUp.js
+++ b/src/events/handleMouseUp.js
@@ -1,10 +1,10 @@
-import { gameState } from "../../index.js";
+import { interactionState } from "../../index.js";
 
 export const handleMouseUp = (event) => {
   console.log("mouseup: " + event.button);
   if (event.button === 0) {
-    gameState.setFlag("leftClick", false);
+    interactionState.setFlag("leftClick", false);
   } else if (event.button === 2) {
-    gameState.setFlag("rightClick", false);
+    interactionState.setFlag("rightClick", false);
   }
 }

--- a/src/objects/PlayerShip.js
+++ b/src/objects/PlayerShip.js
@@ -7,11 +7,21 @@ import {
   PLAYER_SHOOT_INTERVAL,
 } from "../constants.js";
 import { gameState, getCanvasSize, getMousePosition } from "../../index.js";
+import { PlayerBullet } from "./PlayerBullet.js";
 
 export class PlayerShip extends GameObject {
   constructor(x, y) {
     super(x, y, PLAYER_SHIP_WIDTH, PLAYER_SHIP_HEIGHT, PLAYER_SHIP_COLOR);
     this.shootIntervalId = null;
+  }
+
+  /**
+   * 射撃処理
+   * @param {number} direction 射撃方向（ラジアン角度で指定）
+   */
+  shoot(direction) {
+    const bullet = new PlayerBullet(this.x, this.y, direction, 10);
+    gameState.registerObject(bullet);
   }
 
   updatePosition(flags) {
@@ -34,7 +44,7 @@ export class PlayerShip extends GameObject {
       this.shootIntervalId = setInterval(() => {
         const { mouseX, mouseY } = getMousePosition();
         const direction = Math.atan2(mouseY - this.y, mouseX - this.x);
-        gameState.shoot(direction);
+        this.shoot(direction);
         console.log(mouseX, mouseY, this.x, this.y);
       }, PLAYER_SHOOT_INTERVAL);
     } else if (!flags.leftClick && this.shootIntervalId !== null) {

--- a/src/states/GameState.js
+++ b/src/states/GameState.js
@@ -2,21 +2,13 @@ import { PlayerShip } from "../objects/PlayerShip.js";
 import { PlayerBullet } from "../objects/PlayerBullet.js";
 import { EnemyObject } from "../objects/EnemyObject.js";
 
+import { interactionState } from "../../index.js";
+
 export class GameState {
   constructor() {
     this.objects = [
       new PlayerShip(0, 0),
     ];
-
-    // TODO: ビットフラグ形式にリファクタ
-    this.interactFlags = {
-      up: false,
-      down: false,
-      left: false,
-      right: false,
-      leftClick: false,
-      rightClick: false,
-    };
   }
 
   /**
@@ -25,32 +17,6 @@ export class GameState {
    */
   registerObject(obj) {
     this.objects.push(obj);
-  }
-
-  /**
-   * 特定のフラグが立っているかどうかを取得する。
-   * @param {string} name フラグ名
-   * @returns {boolean} フラグの値
-   */
-  isFlag(name) {
-    if (this.interactFlags.hasOwnProperty(name)) {
-      return this.interactFlags[name];
-    } else {
-      throw new Error(`Invalid flag name: ${name}`);
-    }
-  }
-
-  /**
-   * フラグを更新する。
-   * @param {string} flag フラグ名
-   * @param {boolean} value フラグの値
-   */
-  setFlag(flag, value) {
-    if (this.interactFlags.hasOwnProperty(flag)) {
-      this.interactFlags[flag] = value;
-    } else {
-      throw new Error(`Invalid flag name: ${flag}`);
-    }
   }
 
   /**
@@ -76,7 +42,7 @@ export class GameState {
    */
   updatePlayerPosition = () => {
     const player = this.getFirst(PlayerShip);
-    const flags = this.interactFlags;
+    const flags = interactionState.getAllFlags();
     player.updatePosition(flags);
   };
 

--- a/src/states/GameState.js
+++ b/src/states/GameState.js
@@ -53,34 +53,38 @@ export class GameState {
     }
   }
 
-  // プレイヤー関連
   /**
-   * プレイヤーを取得する
-   * @returns {PlayerShip}
+   * 特定のクラスオブジェクトのうち、最初のオブジェクトを取得する。
+   * @param {Function} classObj 取得するクラスオブジェクト
+   * @returns {Object} 取得したオブジェクト
    */
-  getPlayerObj = () => this.objects.find((obj) => obj instanceof PlayerShip);
+  getFirst(classObj) {
+    return this.objects.find((obj) => obj instanceof classObj);
+  }
+
+  /**
+   * 特定のクラスオブジェクトをすべて取得する。
+   * @param {Function} classObj 取得するクラスオブジェクト
+   * @returns {Object[]} 取得したオブジェクトの配列
+   */
+  getAll(classObj) {
+    return this.objects.filter((obj) => obj instanceof classObj);
+  }
 
   /**
    * プレイヤーの位置を更新する
    */
   updatePlayerPosition = () => {
-    const player = this.getPlayerObj();
+    const player = this.getFirst(PlayerShip);
     const flags = this.interactFlags;
     player.updatePosition(flags);
   };
 
   /**
-   * プレイヤーの弾を取得する
-   * @returns {PlayerBullet[]}
-   */
-  getAllPlayerBullets = () =>
-    this.objects.filter((obj) => obj instanceof PlayerBullet);
-
-  /**
    * 弾の位置を更新する
    */
   updateBulletsPosition() {
-    const bullets = this.getAllPlayerBullets();
+    const bullets = this.getAll(PlayerBullet);
 
     bullets.forEach((bullet) => {
       bullet.updatePosition();
@@ -94,18 +98,11 @@ export class GameState {
     });
   }
 
-  // 敵オブジェクト関連
-  /**
-   * 敵オブジェクトを取得する
-   * @returns {EnemyObject[]}
-   */
-  getAllEnemyObjects = () => this.objects.filter((obj) => obj instanceof EnemyObject);
-
   /**
    * 敵オブジェクトの状態を更新する
    */
   updateEnemyObjects() {
-    const enemies = this.getAllEnemyObjects();
+    const enemies = this.getAll(EnemyObject);
     enemies.forEach((enemy) => {
       if (enemy.hp <= 0) {
         this.objects.splice(this.objects.indexOf(enemy), 1);
@@ -117,8 +114,8 @@ export class GameState {
    * PlayerBulletとの衝突判定を行う
    */
   checkBulletCollision() {
-    const bullets = this.getAllPlayerBullets();
-    const enemies = this.getAllEnemyObjects();
+    const bullets = this.getAll(PlayerBullet);
+    const enemies = this.getAll(EnemyObject);
 
     // TODO: O(N^2) なので、パフォーマンスを改善する
     bullets.forEach((bullet) => {

--- a/src/states/GameState.js
+++ b/src/states/GameState.js
@@ -20,6 +20,14 @@ export class GameState {
   }
 
   /**
+   * オブジェクトを登録する
+   * @param {Object} obj 登録するオブジェクト
+   */
+  registerObject(obj) {
+    this.objects.push(obj);
+  }
+
+  /**
    * 特定のフラグが立っているかどうかを取得する。
    * @param {string} name フラグ名
    * @returns {boolean} フラグの値
@@ -60,17 +68,6 @@ export class GameState {
     const flags = this.interactFlags;
     player.updatePosition(flags);
   };
-
-  // 弾関連
-  /**
-   * 射撃処理
-   * @param {number} direction 射撃方向（ラジアン角度で指定）
-   */
-  shoot(direction) {
-    const player = this.getPlayerObj();
-    const bullet = new PlayerBullet(player.x, player.y, direction, 10);
-    this.objects.push(bullet);
-  }
 
   /**
    * プレイヤーの弾を取得する

--- a/src/states/InteractionState.js
+++ b/src/states/InteractionState.js
@@ -1,0 +1,47 @@
+export class InteractionState {
+  constructor() {
+    // TODO: ビットフラグ形式にリファクタ
+    this.interactFlags = {
+      up: false,
+      down: false,
+      left: false,
+      right: false,
+      leftClick: false,
+      rightClick: false,
+    };
+  }
+
+  /**
+   * 特定のフラグが立っているかどうかを取得する。
+   * @param {string} name フラグ名
+   * @returns {boolean} フラグの値
+   */
+  isFlag(name) {
+    if (this.interactFlags.hasOwnProperty(name)) {
+      return this.interactFlags[name];
+    } else {
+      throw new Error(`Invalid flag name: ${name}`);
+    }
+  }
+
+  /**
+   * すべてのフラグを取得する。
+   * @returns {Object} フラグの値
+   */
+  getAllFlags() {
+    return this.interactFlags;
+  }
+
+  /**
+   * フラグを更新する。
+   * @param {string} flag フラグ名
+   * @param {boolean} value フラグの値
+   */
+  setFlag(flag, value) {
+    if (this.interactFlags.hasOwnProperty(flag)) {
+      this.interactFlags[flag] = value;
+    } else {
+      throw new Error(`Invalid flag name: ${flag}`);
+    }
+  }
+} 


### PR DESCRIPTION
# Linked Issues
#22 

# Before
`GameState` に様々な関数が乱立していた。

# After
`GameState` が持っていた以下の関数を分離した。
- `shoot()` -> `PlayerShip` 関数へ
- `interactFlags` および操作関数 -> `InteractionState` へ