### PR TITLE
#25: 下方向以外に飛んだ弾が削除されない問題を修正した

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -2,11 +2,12 @@ export const PLAYER_SHIP_WIDTH = 40;
 export const PLAYER_SHIP_HEIGHT = 50;
 export const PLAYER_SHIP_COLOR = "blue";
 export const PLAYER_SPEED = 5;
-export const PLAYER_SHOOT_INTERVAL = 150;
+export const PLAYER_SHOOT_INTERVAL = 50;
 
 export const PLAYER_BULLET_WIDTH = 10;
 export const PLAYER_BULLET_HEIGHT = 10;
 export const PLAYER_BULLET_SPEED = 10;
+export const PLAYER_BULLET_DAMAGE = 1;
 export const PLAYER_BULLET_COLOR = "blue";
 
 export const ENEMY_WIDTH = 20;

--- a/src/objects/PlayerShip.js
+++ b/src/objects/PlayerShip.js
@@ -8,6 +8,7 @@ import {
 } from "../constants.js";
 import { gameState, getCanvasSize, getMousePosition } from "../../index.js";
 import { PlayerBullet } from "./PlayerBullet.js";
+import { PLAYER_BULLET_DAMAGE } from "../constants.js";
 
 export class PlayerShip extends GameObject {
   constructor(x, y) {
@@ -20,7 +21,7 @@ export class PlayerShip extends GameObject {
    * @param {number} direction 射撃方向（ラジアン角度で指定）
    */
   shoot(direction) {
-    const bullet = new PlayerBullet(this.x, this.y, direction, 10);
+    const bullet = new PlayerBullet(this.x, this.y, direction, PLAYER_BULLET_DAMAGE);
     gameState.registerObject(bullet);
   }
 

--- a/src/states/GameState.js
+++ b/src/states/GameState.js
@@ -2,7 +2,7 @@ import { PlayerShip } from "../objects/PlayerShip.js";
 import { PlayerBullet } from "../objects/PlayerBullet.js";
 import { EnemyObject } from "../objects/EnemyObject.js";
 
-import { interactionState } from "../../index.js";
+import { getCanvasSize, interactionState } from "../../index.js";
 
 export class GameState {
   constructor() {
@@ -58,7 +58,9 @@ export class GameState {
       // 画面外に出た弾をobjectsから削除
       // TODO: 全方向に確認する
       // TODO: 計算量が O(N) （Nはすべてのオブジェクト数）なので、パフォーマンスを改善する
-      if (bullet.y < 0) {
+      const { width, height } = getCanvasSize();
+      if (bullet.x < 0 || bullet.x > width ||
+        bullet.y < 0 || bullet.y > height) {
         this.objects.splice(this.objects.indexOf(bullet), 1);
       }
     });

--- a/src/states/GameState.js
+++ b/src/states/GameState.js
@@ -56,7 +56,6 @@ export class GameState {
       bullet.updatePosition();
 
       // 画面外に出た弾をobjectsから削除
-      // TODO: 全方向に確認する
       // TODO: 計算量が O(N) （Nはすべてのオブジェクト数）なので、パフォーマンスを改善する
       const { width, height } = getCanvasSize();
       if (bullet.x < 0 || bullet.x > width ||


### PR DESCRIPTION
# Linned Issues
#25 

# Approach
以下のように、下方向以外のチェックを追加した。
```js
// 画面外に出た弾をobjectsから削除
// TODO: 計算量が O(N) （Nはすべてのオブジェクト数）なので、パフォーマンスを改善する
const { width, height } = getCanvasSize();
if (bullet.x < 0 || bullet.x > width ||
  bullet.y < 0 || bullet.y > height) {
  this.objects.splice(this.objects.indexOf(bullet), 1);
}
```