### PR TITLE
#29: GameObject を継承したクラスに対し、方向をメンバ変数として追加した

### DIFF
--- a/src/objects/EnemyObject.js
+++ b/src/objects/EnemyObject.js
@@ -1,20 +1,10 @@
-import {
-  ENEMY_WIDTH,
-  ENEMY_HEIGHT,
-  ENEMY_COLOR,
-  ENEMY_HP,
-  ENEMY_SHOOT_INTERVAL,
-} from "../constants.js";
-import { gameState } from "../../index.js";
 import { GameObject } from "./GameObject.js";
-import { EnemyBullet } from "./EnemyBullet.js";
+import { ENEMY_WIDTH, ENEMY_HEIGHT, ENEMY_COLOR, ENEMY_HP } from "../constants.js";
 
 export class EnemyObject extends GameObject {
   constructor(x, y) {
     super(x, y, ENEMY_WIDTH, ENEMY_HEIGHT, ENEMY_COLOR);
     this.hp = ENEMY_HP;
-    this.direction = 0;
-    this.shootIntervalId = null;
   }
 
   /**
@@ -24,23 +14,5 @@ export class EnemyObject extends GameObject {
   damage(damage) {
     this.hp -= damage;
   }
-
-  /**
-   * 弾を発射する
-   */
-  shoot() {
-    const bullet = new EnemyBullet(this.x, this.y, this.direction);
-    gameState.registerObject(bullet);
-  }
-
-  /**
-   * 更新処理
-   */
-  update() {
-    if (!this.shootIntervalId) {
-      this.shootIntervalId = setInterval(() => {
-        this.shoot();
-      }, ENEMY_SHOOT_INTERVAL);
-    }
-  }
 }
+

--- a/src/objects/EnemyObject.js
+++ b/src/objects/EnemyObject.js
@@ -1,10 +1,20 @@
+import {
+  ENEMY_WIDTH,
+  ENEMY_HEIGHT,
+  ENEMY_COLOR,
+  ENEMY_HP,
+  ENEMY_SHOOT_INTERVAL,
+} from "../constants.js";
+import { gameState } from "../../index.js";
 import { GameObject } from "./GameObject.js";
-import { ENEMY_WIDTH, ENEMY_HEIGHT, ENEMY_COLOR, ENEMY_HP } from "../constants.js";
+import { EnemyBullet } from "./EnemyBullet.js";
 
 export class EnemyObject extends GameObject {
   constructor(x, y) {
     super(x, y, ENEMY_WIDTH, ENEMY_HEIGHT, ENEMY_COLOR);
     this.hp = ENEMY_HP;
+    this.direction = 0;
+    this.shootIntervalId = null;
   }
 
   /**
@@ -14,5 +24,23 @@ export class EnemyObject extends GameObject {
   damage(damage) {
     this.hp -= damage;
   }
-}
 
+  /**
+   * 弾を発射する
+   */
+  shoot() {
+    const bullet = new EnemyBullet(this.x, this.y, this.direction);
+    gameState.registerObject(bullet);
+  }
+
+  /**
+   * 更新処理
+   */
+  update() {
+    if (!this.shootIntervalId) {
+      this.shootIntervalId = setInterval(() => {
+        this.shoot();
+      }, ENEMY_SHOOT_INTERVAL);
+    }
+  }
+}

--- a/src/objects/GameObject.js
+++ b/src/objects/GameObject.js
@@ -5,6 +5,7 @@ export class GameObject {
     this.width = width;
     this.height = height;
     this.color = color;
+    this.direction = 0;
   }
 
   updatePosition() {

--- a/src/objects/PlayerShip.js
+++ b/src/objects/PlayerShip.js
@@ -17,10 +17,9 @@ export class PlayerShip extends GameObject {
 
   /**
    * 射撃処理
-   * @param {number} direction 射撃方向（ラジアン角度で指定）
    */
-  shoot(direction) {
-    const bullet = new PlayerBullet(this.x, this.y, direction);
+  shoot() {
+    const bullet = new PlayerBullet(this.x, this.y, this.direction);
     gameState.registerObject(bullet);
   }
 

--- a/src/objects/PlayerShip.js
+++ b/src/objects/PlayerShip.js
@@ -19,6 +19,7 @@ export class PlayerShip extends GameObject {
    * 射撃処理
    */
   shoot() {
+    this.updateDirection();
     const bullet = new PlayerBullet(this.x, this.y, this.direction);
     gameState.registerObject(bullet);
   }
@@ -42,14 +43,19 @@ export class PlayerShip extends GameObject {
     // TODO: updatePosition で射撃処理してるのおかしくない？
     if(flags.leftClick && this.shootIntervalId === null) {
       this.shootIntervalId = setInterval(() => {
-        const { mouseX, mouseY } = getMousePosition();
-        const direction = Math.atan2(mouseY - this.y, mouseX - this.x);
-        this.shoot(direction);
-        console.log(mouseX, mouseY, this.x, this.y);
+        this.shoot();
       }, PLAYER_SHOOT_INTERVAL);
     } else if (!flags.leftClick && this.shootIntervalId !== null) {
       clearInterval(this.shootIntervalId);
       this.shootIntervalId = null;
     }
+  }
+
+  /**
+   * マウスの位置を取得し、プレイヤーの方向を更新
+   */
+  updateDirection() {
+    const { mouseX, mouseY } = getMousePosition();
+    this.direction = Math.atan2(mouseY - this.y, mouseX - this.x);
   }
 }


### PR DESCRIPTION
# Before
射撃処理など方向情報を使用する際は、引数などで指定する方式をとっていた。
たとえば `PlayerShip.shoot()` は引数に `direction` をとり、呼び出し元では都度マウスカーソルの位置から方向を計算していた。
```js
// PlayerShip.js
const { mouseX, mouseY } = getMousePosition();
const direction = Math.atan2(mouseY - this.y, mouseX - this.x);
this.shoot(direction);
```

# After
オブジェクトの方向を`GameObject` のメンバ変数として共通化するようにした。
これにより、`PlayerShip.shoot()` では引数として方向を受け取ることなく、内部で保持された方向情報をもとに射撃処理を行っている。

```js
// PlayerShip.js
/**
 * 射撃処理
 */
shoot() {
  this.updateDirection();
  const bullet = new PlayerBullet(this.x, this.y, this.direction);
  gameState.registerObject(bullet);
}

/**
 * マウスの位置を取得し、プレイヤーの方向を更新
 */
updateDirection() {
  const { mouseX, mouseY } = getMousePosition();
  this.direction = Math.atan2(mouseY - this.y, mouseX - this.x);
}
```